### PR TITLE
Remove phalcon extension dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
   ],
   "require": {
     "php": ">=5.5",
-    "ext-phalcon" : ">=2.0.0",
     "phalcon/incubator": "2.0.8",
     "robmorgan/phinx": "^0.5.0"
   },


### PR DESCRIPTION
Remove phalcon dependency to ensure project can be used as dependency in environments without phalcon extension
