### PR TITLE
Ensure that random passwords contain at least one number

### DIFF
--- a/src/Libraries/Utils.php
+++ b/src/Libraries/Utils.php
@@ -59,16 +59,16 @@ class Utils
      */
     public static function generateRandomString($length, $strict = true)
     {
-        $password = Text::random(Text::RANDOM_ALNUM, $length);
-
         if (!$strict) {
-            return $password;
+            return Text::random(Text::RANDOM_ALNUM, $length);
         }
+
+        $password = self::generateRandomString($length - 1, false);
 
         //todo may add more symbols later
         $shuffledSymbols = str_shuffle("@#$%^&*!+-_~");
 
-        return substr($password, 0, strlen($password) - 1) . $shuffledSymbols[0];
+        return substr($password, 0, strlen($password) - 1) . $shuffledSymbols[0] . Text::random(Text::RANDOM_NUMERIC, 1);
     }
 
     /**

--- a/tests/passwordGenerationTest.php
+++ b/tests/passwordGenerationTest.php
@@ -26,4 +26,15 @@ class PasswordGenerationTest extends \UnitTestCase
         }
         $this->assertEquals($passwordsArray, array_unique($passwordsArray));
     }
+
+    /**
+     * Test that passwords must contain at least number
+     */
+    public function testPasswordContainsNumber()
+    {
+        for ($i=0; $i<1000; $i++){
+            $password = User::generateRandomPassword();
+            $this->assertTrue(preg_match('/\\d/', $password) > 0);
+        }
+    }
 }


### PR DESCRIPTION
When a random password is generated, sometimes, the number gets replaced with a special character making the password unable to pass validation. 